### PR TITLE
Updated routing key matching with line start and end

### DIFF
--- a/pubsub/subscriber.py
+++ b/pubsub/subscriber.py
@@ -115,7 +115,9 @@ class Worker(ConsumerMixin):
             return string
 
         routing_key_els = routing_key.split(".")
-        routing_key_els_regex = "\.".join([convert(i) for i in routing_key_els])
+        routing_key_joined = "\.".join([convert(i) for i in routing_key_els])
+        # Specify line start and end to avoid matching similar routing keys
+        routing_key_els_regex = f"^{routing_key_joined}$"
         return re.match(routing_key_els_regex, test_string) is not None
 
 

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -76,7 +76,9 @@ def test_routing_keys_match():
     assert Worker.does_routing_key_match("test.this.key", "test.this.key") is True
     assert Worker.does_routing_key_match("test.this.key", "test.this.keys") is False
     assert Worker.does_routing_key_match("test.this.key", "tests.this.key") is False
-    assert Worker.does_routing_key_match("test.this.key_extra", "test.this.key") is False
+    assert (
+        Worker.does_routing_key_match("test.this.key_extra", "test.this.key") is False
+    )
 
     assert Worker.does_routing_key_match("test.this.key", "test.*.key") is True
     assert Worker.does_routing_key_match("test.that.key", "test.*.key") is True

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -76,6 +76,7 @@ def test_routing_keys_match():
     assert Worker.does_routing_key_match("test.this.key", "test.this.key") is True
     assert Worker.does_routing_key_match("test.this.key", "test.this.keys") is False
     assert Worker.does_routing_key_match("test.this.key", "tests.this.key") is False
+    assert Worker.does_routing_key_match("test.this.key_extra", "test.this.key") is False
 
     assert Worker.does_routing_key_match("test.this.key", "test.*.key") is True
     assert Worker.does_routing_key_match("test.that.key", "test.*.key") is True
@@ -83,4 +84,4 @@ def test_routing_keys_match():
 
     assert Worker.does_routing_key_match("test.this.key", "test.#.key") is True
     assert Worker.does_routing_key_match("test.this.that.key", "test.#.key") is True
-    assert Worker.does_routing_key_match("test.this.keys", "test.#.key") is True
+    assert Worker.does_routing_key_match("test.this.keys", "test.#.key") is False


### PR DESCRIPTION
Authinator is publishing two routing keys with similar names:

"authinator.user.access_request"
"authinator.user.access_request_action"

This is causing Alerts to run tasks mapped to the first routing key when the second routing key is published.

This PR specifies a line start ^ and line end $ in the regex to prevent this